### PR TITLE
Fix mobile image background overflow

### DIFF
--- a/src/assets/styles/HomePage.module.css
+++ b/src/assets/styles/HomePage.module.css
@@ -24,17 +24,6 @@
   margin-top: 5.563rem;
 }
 
-/*
-.background-main::before {
-  content: "";
-  width: 100%;
-  height: 100%;
-  background-image: url("../images/banner-home.svg");
-  background-position: center;
-  background-repeat: no-repeat;
-}
-*/
-
 .main {
   position: relative;
   display: flex;
@@ -819,7 +808,7 @@ section.registro-processo .processo-lider .processo p {
   .background-main {
     width: 100%;
     height: 100%;
-    min-height: 100vh;
+/*    min-height: 100vh; */
     display: flex;
     align-items: flex-start;
     padding: 0%;


### PR DESCRIPTION
# Changes Summary

1. Fixed the mobile ```min-height``` property on layout for the home page to correct  background image to overflow.
2. Deleted commented code.

